### PR TITLE
Fix OCI repository URL resolution to prevent duplicate name fragments

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -144,7 +144,7 @@ func generateImagePurlVariants(registryString, imageName, digestString, tag, os,
 	// Purl with full qualifiers
 	qMap := map[string]string{}
 	if registryString != "" {
-		qMap["repository_url"] = strings.TrimSuffix(registryString, "/")
+		qMap["repository_url"] = registryString + imageName
 	}
 
 	purls = append(purls,
@@ -233,10 +233,8 @@ func PurlToReferenceString(purlString string, fopts ...RefConverterOptions) (str
 	qualifiers := p.Qualifiers.Map()
 
 	refString := p.Name
-	if _, ok := qualifiers["repository_url"]; ok {
-		refString = fmt.Sprintf(
-			"%s/%s", strings.TrimSuffix(qualifiers["repository_url"], "/"), p.Name,
-		)
+	if v, ok := qualifiers["repository_url"]; ok {
+		refString = v
 	} else if opts.DefaultRepository != "" {
 		refString = fmt.Sprintf(
 			"%s/%s", strings.TrimSuffix(opts.DefaultRepository, "/"), p.Name,

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -24,10 +24,10 @@ func TestGenerateReferenceIdentifiers(t *testing.T) {
 			expected: IdentifiersBundle{
 				Identifiers: map[vex.IdentifierType][]string{
 					vex.PURL: {
-						"pkg:oci/alpine@sha256%3Aeece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978?repository_url=index.docker.io%2Flibrary",
-						"pkg:oci/alpine@sha256%3Aeece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary",
-						"pkg:oci/alpine@sha256%3A48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86?repository_url=index.docker.io%2Flibrary",
-						"pkg:oci/alpine@sha256%3A48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary",
+						"pkg:oci/alpine@sha256%3Aeece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978?repository_url=index.docker.io%2Flibrary%2Falpine",
+						"pkg:oci/alpine@sha256%3Aeece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary%2Falpine",
+						"pkg:oci/alpine@sha256%3A48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86?repository_url=index.docker.io%2Flibrary%2Falpine",
+						"pkg:oci/alpine@sha256%3A48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary%2Falpine",
 					},
 				},
 				Hashes: map[vex.Algorithm][]vex.Hash{
@@ -45,8 +45,8 @@ func TestGenerateReferenceIdentifiers(t *testing.T) {
 			expected: IdentifiersBundle{
 				Identifiers: map[vex.IdentifierType][]string{
 					vex.PURL: {
-						"pkg:oci/curl@sha256%3A3b987bc327e8aa8e7db26822e0552d927d25392ccb4d3b9d30b5390b485520d8?repository_url=cgr.dev%2Fchainguard",
-						"pkg:oci/curl@sha256%3A3b987bc327e8aa8e7db26822e0552d927d25392ccb4d3b9d30b5390b485520d8?arch=amd64&os=linux&repository_url=cgr.dev%2Fchainguard",
+						"pkg:oci/curl@sha256%3A3b987bc327e8aa8e7db26822e0552d927d25392ccb4d3b9d30b5390b485520d8?repository_url=cgr.dev%2Fchainguard%2Fcurl",
+						"pkg:oci/curl@sha256%3A3b987bc327e8aa8e7db26822e0552d927d25392ccb4d3b9d30b5390b485520d8?arch=amd64&os=linux&repository_url=cgr.dev%2Fchainguard%2Fcurl",
 					},
 				},
 				Hashes: map[vex.Algorithm][]vex.Hash{
@@ -63,10 +63,10 @@ func TestGenerateReferenceIdentifiers(t *testing.T) {
 			expected: IdentifiersBundle{
 				Identifiers: map[vex.IdentifierType][]string{
 					vex.PURL: {
-						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?repository_url=localhost%3A5000",
-						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi",
-						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?repository_url=localhost%3A5000",
-						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi",
+						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?repository_url=localhost%3A5000%2Fscanner-test",
+						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi%2Fscanner-test",
+						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?repository_url=localhost%3A5000%2Fscanner-test",
+						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi%2Fscanner-test",
 					},
 				},
 				Hashes: map[vex.Algorithm][]vex.Hash{
@@ -89,8 +89,8 @@ func TestGenerateReferenceIdentifiers(t *testing.T) {
 			expected: IdentifiersBundle{
 				Identifiers: map[vex.IdentifierType][]string{
 					vex.PURL: {
-						"pkg:oci/alpine@sha256%3Affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff?repository_url=index.docker.io%2Flibrary",
-						"pkg:oci/alpine@sha256%3Affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary",
+						"pkg:oci/alpine@sha256%3Affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff?repository_url=index.docker.io%2Flibrary%2Falpine",
+						"pkg:oci/alpine@sha256%3Affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff?arch=amd64&os=linux&repository_url=index.docker.io%2Flibrary%2Falpine",
 					},
 				},
 				Hashes: map[vex.Algorithm][]vex.Hash{
@@ -131,7 +131,7 @@ func TestPurlToReferenceString(t *testing.T) {
 		},
 		{
 			"normal-with-repo",
-			"pkg:oci/curl@sha256%3A47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c?repository_url=cgr.dev/chainguard/",
+			"pkg:oci/curl@sha256%3A47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c?repository_url=cgr.dev/chainguard/curl",
 			"cgr.dev/chainguard/curl@sha256:47fed8868b46b060efb8699dc40e981a0c785650223e03602d8c4493fc75b68c",
 			[]RefConverterOptions{},
 			false,
@@ -175,7 +175,7 @@ func TestPurlToReferenceString(t *testing.T) {
 		},
 		{
 			"repo-override",
-			"pkg:oci/pause:latest?repository_url=k8s.gcr.io/",
+			"pkg:oci/pause:latest?repository_url=k8s.gcr.io/pause",
 			"registry.k8s.io/release/pause:latest",
 			[]RefConverterOptions{
 				WithOverrideRepository("registry.k8s.io/release/"),

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -64,9 +64,9 @@ func TestGenerateReferenceIdentifiers(t *testing.T) {
 				Identifiers: map[vex.IdentifierType][]string{
 					vex.PURL: {
 						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?repository_url=localhost%3A5000%2Fscanner-test",
-						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi%2Fscanner-test",
+						"pkg:oci/scanner-test@sha256%3Aa0acdc09bf31ac45076a5850d0564ee144a9c8483f89eb869dc6ddd6218629c9?arch=amd64&os=linux&repository_url=localhost%3A5000%2Fscanner-test&tag=unfixed-vulnerabilities-wolfi",
 						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?repository_url=localhost%3A5000%2Fscanner-test",
-						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?arch=amd64&os=linux&repository_url=localhost%3A5000&tag=unfixed-vulnerabilities-wolfi%2Fscanner-test",
+						"pkg:oci/scanner-test@sha256%3A86e3ee69ede5f56514972d16fcfcfafbb54a65d2349c6f8419670bf7993d8583?arch=amd64&os=linux&repository_url=localhost%3A5000%2Fscanner-test&tag=unfixed-vulnerabilities-wolfi",
 					},
 				},
 				Hashes: map[vex.Algorithm][]vex.Hash{


### PR DESCRIPTION
## Description
This PR addresses an issue with the current implementation of OCI PURL repository URL resolution. According to [the PURL specification](https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst#oci), for the `oci` type, the 'name' should be the last fragment of the repository name, and it should not be unnecessarily appended to the repository URL.

### Current behavior:
For a PURL like `pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye`
The implementation incorrectly resolves the repository URL to: ghcr.io/debian/debian:bullseye

### Desired behavior:
The repository URL should resolve to: ghcr.io/debian:bullseye

Please correct me if I'm missing something. Thanks.