### PR TITLE
Bump golangci-lint to v2.1

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+---
 name: Run e2e Tests
 
 on:
@@ -13,6 +16,8 @@ jobs:
     steps:
         - name: Check out code onto GOPATH
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          with:
+            persist-credentials: false
 
         - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
           name: Setup crane 🪿 ♥️ 🏗️

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+---
 name: golangci-lint
 on:
   pull_request:
@@ -13,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '1.24'
@@ -20,6 +25,6 @@ jobs:
           check-latest: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64
+          version: v2.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright 2023 The OpenVEX Authors
 # SPDX-License-Identifier: Apache-2.0
-
+---
 name: Release
 
 on:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,156 +1,183 @@
+# SPDX-FileCopyrightText: Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
 ---
+version: "2"
 run:
   concurrency: 6
   timeout: 5m
 issues:
-  exclude-rules:
-    # counterfeiter fakes are usually named 'fake_<something>.go'
-    - path: fake_.*\.go
-      linters:
-        - gocritic
-        - golint
-        - dupl
-
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
-linters:
-  disable-all: true
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
   enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    # - golines
+  settings: 
+    gci:
+      no-inline-comments: false
+      no-prefix-comments: true
+      sections:
+        - standard
+        - default
+        - prefix(github.com/openvex/discovery)
+linters:
+  enable:
+    - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - decorder
     - dogsled
     - dupl
     - durationcheck
     - errcheck
-    # - goconst Disabled temporarily as we need to const away all the relationships
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - forcetypeassert
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goconst
     - gocritic
-    # - gocyclo Disables until some functions are optimized
+    - gocyclo
+    # - godot
     - godox
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
+    - gosmopolitan
     - govet
+    - grouper
+    - iface
     - importas
     - ineffassign
+    - intrange
+    - loggercheck
     - makezero
+    - mirror
     - misspell
+    - musttag
     - nakedret
+    - nilerr
+    - nilnesserr
+    # - nlreturn
+    - noctx
     - nolintlint
+    - nosprintfhostport
+    # - perfsprint
     - prealloc
     - predeclared
     - promlinter
-    # - revive Disabled for now as we have lots of uppercase consts
+    - protogetter
+    - reassign
+    - recvcheck
+    # - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
     - staticcheck
-    # - stylecheck
-    - typecheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - tparallel
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
     - whitespace
-    # - cyclop
-    # - errorlint
-    # - exhaustive
-    # - exhaustivestruct
-    # - exportloopref
-    # - forbidigo
-    # - forcetypeassert
-    # - funlen
-    # - gci
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
-    # - godot
-    # - goerr113
-    # - gomnd
-    # - ifshort
-    # - lll
-    # - nestif
-    # - nilerr
-    # - nlreturn
-    # - noctx
-    # - paralleltest
-    # - scopelint
-    # - tagliatelle
-    # - testpackage
-    # - thelper
-    # - tparallel
-    # - wastedassign
-    # - wrapcheck
     # - wsl
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/bom-squad/protobom)
-  godox:
-    keywords:
-      - BUG
-      - FIXME
-      - HACK
-  errcheck:
-    check-type-assertions: false
-    check-blank: true
-  gocritic:
-    enabled-checks:
-      # Diagnostic
-      - commentedOutCode
-      - nilValReturn
-      - sloppyReassign
-      - weakCond
-      - octalLiteral
+    - zerologlint
 
-      # Performance
-      - appendCombine
-      - equalFold
-      - hugeParam
-      - indexAlloc
-      - rangeExprCopy
-      - rangeValCopy
+  settings:
+    gocyclo:
+      min-complexity: 35
+    godox:
+      keywords:
+        - BUG
+        - FIXME
+        - HACK
+    gosmopolitan:
+      # Allow and ignore `time.Local` usages.
+      #
+      # Default: false
+      allow-time-local: true
+    perfsprint:
+      integer-format: false
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocritic:
+      enabled-checks:
+        # Diagnostic
+        - commentedOutCode
+        - nilValReturn
+        - sloppyReassign
+        - weakCond
+        - octalLiteral
 
-      # Style
-      - boolExprSimplify
-      - commentedOutImport
-      - docStub
-      - emptyFallthrough
-      - emptyStringTest
-      - hexLiteral
-      - methodExprCall
-      - stringXbytes
-      - typeAssertChain
-      - unlabelStmt
-      - yodaStyleExpr
-      # - ifElseChain
+        # Performance
+        - appendCombine
+        - equalFold
+        - hugeParam
+        - indexAlloc
+        - rangeExprCopy
+        - rangeValCopy
 
-      # Opinionated
-      - builtinShadow
-      - importShadow
-      - initClause
-      - nestingReduce
-      - paramTypeCombine
-      - ptrToRefParam
-      - typeUnparen
-      - unnamedResult
-    settings:
-      hugeParam:
-        sizeThreshold: 150 # Handle package url as param
+        # Style
+        - boolExprSimplify
+        - commentedOutImport
+        - docStub
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - methodExprCall
+        - stringXbytes
+        - typeAssertChain
+        - unlabelStmt
+        - yodaStyleExpr
+        # - ifElseChain
 
-  nolintlint:
-    # Enable to ensure that nolint directives are all used. Default is true.
-    allow-unused: false
-    # Exclude following linters from requiring an explanation.  Default is [].
-    allow-no-explanation: []
-    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
-    # TODO(lint): Enforce explanations for `nolint` directives
-    require-explanation: false
-    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
-    require-specific: true
+        # Opinionated
+        - builtinShadow
+        - importShadow
+        - initClause
+        - nestingReduce
+        - paramTypeCombine
+        - ptrToRefParam
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+    gosec:
+      excludes:
+        - G304
+    nolintlint:
+      # Enable to ensure that nolint directives are all used. Default is true.
+      allow-unused: false
+      # Exclude following linters from requiring an explanation.  Default is [].
+      allow-no-explanation: []
+      # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+      # TODO(lint): Enforce explanations for `nolint` directives
+      require-explanation: false
+      # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+      require-specific: true

--- a/pkg/discovery/agent.go
+++ b/pkg/discovery/agent.go
@@ -12,9 +12,8 @@ import (
 	"github.com/openvex/go-vex/pkg/vex"
 	purl "github.com/package-url/packageurl-go"
 
-	"github.com/openvex/discovery/pkg/probers/oci"
-
 	"github.com/openvex/discovery/pkg/discovery/options"
+	"github.com/openvex/discovery/pkg/probers/oci"
 )
 
 var (

--- a/pkg/discovery/agent_test.go
+++ b/pkg/discovery/agent_test.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openvex/discovery/pkg/discovery"
-	"github.com/openvex/discovery/pkg/discovery/discoveryfakes"
 	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openvex/discovery/pkg/discovery"
+	"github.com/openvex/discovery/pkg/discovery/discoveryfakes"
 )
 
 func TestProbePurl(t *testing.T) {
@@ -34,7 +35,7 @@ func TestProbePurl(t *testing.T) {
 			name: "parsepParsePurl fails",
 			prepare: func(a *discovery.Agent) {
 				impl := &discoveryfakes.FakeAgentImplementation{}
-				impl.ParsePurlReturns(packageurl.PackageURL{}, syntErr)
+				impl.ParsePurlReturns(&packageurl.PackageURL{}, syntErr)
 				a.SetImplementation(impl)
 			},
 			mustErr: true,
@@ -43,7 +44,7 @@ func TestProbePurl(t *testing.T) {
 			name: "GetPackageProbe fails",
 			prepare: func(a *discovery.Agent) {
 				impl := &discoveryfakes.FakeAgentImplementation{}
-				impl.ParsePurlReturns(packageurl.PackageURL{}, nil)
+				impl.ParsePurlReturns(&packageurl.PackageURL{}, nil)
 				impl.GetPackageProbeReturns(nil, syntErr)
 				a.SetImplementation(impl)
 			},
@@ -53,7 +54,7 @@ func TestProbePurl(t *testing.T) {
 			name: "FindDocumentsFromPurl fails",
 			prepare: func(a *discovery.Agent) {
 				impl := &discoveryfakes.FakeAgentImplementation{}
-				impl.ParsePurlReturns(packageurl.PackageURL{}, nil)
+				impl.ParsePurlReturns(&packageurl.PackageURL{}, nil)
 				impl.FindDocumentsFromPurlReturns(nil, syntErr)
 				a.SetImplementation(impl)
 			},

--- a/pkg/discovery/discoveryfakes/fake_agent_implementation.go
+++ b/pkg/discovery/discoveryfakes/fake_agent_implementation.go
@@ -11,12 +11,12 @@ import (
 )
 
 type FakeAgentImplementation struct {
-	FindDocumentsFromPurlStub        func(options.Options, discovery.VexProbe, packageurl.PackageURL) ([]*vex.VEX, error)
+	FindDocumentsFromPurlStub        func(options.Options, discovery.VexProbe, *packageurl.PackageURL) ([]*vex.VEX, error)
 	findDocumentsFromPurlMutex       sync.RWMutex
 	findDocumentsFromPurlArgsForCall []struct {
 		arg1 options.Options
 		arg2 discovery.VexProbe
-		arg3 packageurl.PackageURL
+		arg3 *packageurl.PackageURL
 	}
 	findDocumentsFromPurlReturns struct {
 		result1 []*vex.VEX
@@ -26,11 +26,11 @@ type FakeAgentImplementation struct {
 		result1 []*vex.VEX
 		result2 error
 	}
-	GetPackageProbeStub        func(options.Options, packageurl.PackageURL) (discovery.VexProbe, error)
+	GetPackageProbeStub        func(options.Options, *packageurl.PackageURL) (discovery.VexProbe, error)
 	getPackageProbeMutex       sync.RWMutex
 	getPackageProbeArgsForCall []struct {
 		arg1 options.Options
-		arg2 packageurl.PackageURL
+		arg2 *packageurl.PackageURL
 	}
 	getPackageProbeReturns struct {
 		result1 discovery.VexProbe
@@ -40,30 +40,30 @@ type FakeAgentImplementation struct {
 		result1 discovery.VexProbe
 		result2 error
 	}
-	ParsePurlStub        func(string) (packageurl.PackageURL, error)
+	ParsePurlStub        func(string) (*packageurl.PackageURL, error)
 	parsePurlMutex       sync.RWMutex
 	parsePurlArgsForCall []struct {
 		arg1 string
 	}
 	parsePurlReturns struct {
-		result1 packageurl.PackageURL
+		result1 *packageurl.PackageURL
 		result2 error
 	}
 	parsePurlReturnsOnCall map[int]struct {
-		result1 packageurl.PackageURL
+		result1 *packageurl.PackageURL
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAgentImplementation) FindDocumentsFromPurl(arg1 options.Options, arg2 discovery.VexProbe, arg3 packageurl.PackageURL) ([]*vex.VEX, error) {
+func (fake *FakeAgentImplementation) FindDocumentsFromPurl(arg1 options.Options, arg2 discovery.VexProbe, arg3 *packageurl.PackageURL) ([]*vex.VEX, error) {
 	fake.findDocumentsFromPurlMutex.Lock()
 	ret, specificReturn := fake.findDocumentsFromPurlReturnsOnCall[len(fake.findDocumentsFromPurlArgsForCall)]
 	fake.findDocumentsFromPurlArgsForCall = append(fake.findDocumentsFromPurlArgsForCall, struct {
 		arg1 options.Options
 		arg2 discovery.VexProbe
-		arg3 packageurl.PackageURL
+		arg3 *packageurl.PackageURL
 	}{arg1, arg2, arg3})
 	stub := fake.FindDocumentsFromPurlStub
 	fakeReturns := fake.findDocumentsFromPurlReturns
@@ -84,13 +84,13 @@ func (fake *FakeAgentImplementation) FindDocumentsFromPurlCallCount() int {
 	return len(fake.findDocumentsFromPurlArgsForCall)
 }
 
-func (fake *FakeAgentImplementation) FindDocumentsFromPurlCalls(stub func(options.Options, discovery.VexProbe, packageurl.PackageURL) ([]*vex.VEX, error)) {
+func (fake *FakeAgentImplementation) FindDocumentsFromPurlCalls(stub func(options.Options, discovery.VexProbe, *packageurl.PackageURL) ([]*vex.VEX, error)) {
 	fake.findDocumentsFromPurlMutex.Lock()
 	defer fake.findDocumentsFromPurlMutex.Unlock()
 	fake.FindDocumentsFromPurlStub = stub
 }
 
-func (fake *FakeAgentImplementation) FindDocumentsFromPurlArgsForCall(i int) (options.Options, discovery.VexProbe, packageurl.PackageURL) {
+func (fake *FakeAgentImplementation) FindDocumentsFromPurlArgsForCall(i int) (options.Options, discovery.VexProbe, *packageurl.PackageURL) {
 	fake.findDocumentsFromPurlMutex.RLock()
 	defer fake.findDocumentsFromPurlMutex.RUnlock()
 	argsForCall := fake.findDocumentsFromPurlArgsForCall[i]
@@ -123,12 +123,12 @@ func (fake *FakeAgentImplementation) FindDocumentsFromPurlReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
-func (fake *FakeAgentImplementation) GetPackageProbe(arg1 options.Options, arg2 packageurl.PackageURL) (discovery.VexProbe, error) {
+func (fake *FakeAgentImplementation) GetPackageProbe(arg1 options.Options, arg2 *packageurl.PackageURL) (discovery.VexProbe, error) {
 	fake.getPackageProbeMutex.Lock()
 	ret, specificReturn := fake.getPackageProbeReturnsOnCall[len(fake.getPackageProbeArgsForCall)]
 	fake.getPackageProbeArgsForCall = append(fake.getPackageProbeArgsForCall, struct {
 		arg1 options.Options
-		arg2 packageurl.PackageURL
+		arg2 *packageurl.PackageURL
 	}{arg1, arg2})
 	stub := fake.GetPackageProbeStub
 	fakeReturns := fake.getPackageProbeReturns
@@ -149,13 +149,13 @@ func (fake *FakeAgentImplementation) GetPackageProbeCallCount() int {
 	return len(fake.getPackageProbeArgsForCall)
 }
 
-func (fake *FakeAgentImplementation) GetPackageProbeCalls(stub func(options.Options, packageurl.PackageURL) (discovery.VexProbe, error)) {
+func (fake *FakeAgentImplementation) GetPackageProbeCalls(stub func(options.Options, *packageurl.PackageURL) (discovery.VexProbe, error)) {
 	fake.getPackageProbeMutex.Lock()
 	defer fake.getPackageProbeMutex.Unlock()
 	fake.GetPackageProbeStub = stub
 }
 
-func (fake *FakeAgentImplementation) GetPackageProbeArgsForCall(i int) (options.Options, packageurl.PackageURL) {
+func (fake *FakeAgentImplementation) GetPackageProbeArgsForCall(i int) (options.Options, *packageurl.PackageURL) {
 	fake.getPackageProbeMutex.RLock()
 	defer fake.getPackageProbeMutex.RUnlock()
 	argsForCall := fake.getPackageProbeArgsForCall[i]
@@ -188,7 +188,7 @@ func (fake *FakeAgentImplementation) GetPackageProbeReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeAgentImplementation) ParsePurl(arg1 string) (packageurl.PackageURL, error) {
+func (fake *FakeAgentImplementation) ParsePurl(arg1 string) (*packageurl.PackageURL, error) {
 	fake.parsePurlMutex.Lock()
 	ret, specificReturn := fake.parsePurlReturnsOnCall[len(fake.parsePurlArgsForCall)]
 	fake.parsePurlArgsForCall = append(fake.parsePurlArgsForCall, struct {
@@ -213,7 +213,7 @@ func (fake *FakeAgentImplementation) ParsePurlCallCount() int {
 	return len(fake.parsePurlArgsForCall)
 }
 
-func (fake *FakeAgentImplementation) ParsePurlCalls(stub func(string) (packageurl.PackageURL, error)) {
+func (fake *FakeAgentImplementation) ParsePurlCalls(stub func(string) (*packageurl.PackageURL, error)) {
 	fake.parsePurlMutex.Lock()
 	defer fake.parsePurlMutex.Unlock()
 	fake.ParsePurlStub = stub
@@ -226,28 +226,28 @@ func (fake *FakeAgentImplementation) ParsePurlArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeAgentImplementation) ParsePurlReturns(result1 packageurl.PackageURL, result2 error) {
+func (fake *FakeAgentImplementation) ParsePurlReturns(result1 *packageurl.PackageURL, result2 error) {
 	fake.parsePurlMutex.Lock()
 	defer fake.parsePurlMutex.Unlock()
 	fake.ParsePurlStub = nil
 	fake.parsePurlReturns = struct {
-		result1 packageurl.PackageURL
+		result1 *packageurl.PackageURL
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeAgentImplementation) ParsePurlReturnsOnCall(i int, result1 packageurl.PackageURL, result2 error) {
+func (fake *FakeAgentImplementation) ParsePurlReturnsOnCall(i int, result1 *packageurl.PackageURL, result2 error) {
 	fake.parsePurlMutex.Lock()
 	defer fake.parsePurlMutex.Unlock()
 	fake.ParsePurlStub = nil
 	if fake.parsePurlReturnsOnCall == nil {
 		fake.parsePurlReturnsOnCall = make(map[int]struct {
-			result1 packageurl.PackageURL
+			result1 *packageurl.PackageURL
 			result2 error
 		})
 	}
 	fake.parsePurlReturnsOnCall[i] = struct {
-		result1 packageurl.PackageURL
+		result1 *packageurl.PackageURL
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/discovery/implementation.go
+++ b/pkg/discovery/implementation.go
@@ -15,24 +15,24 @@ import (
 //counterfeiter:generate . agentImplementation
 
 type agentImplementation interface {
-	ParsePurl(string) (purl.PackageURL, error)
-	GetPackageProbe(options.Options, purl.PackageURL) (VexProbe, error)
-	FindDocumentsFromPurl(options.Options, VexProbe, purl.PackageURL) ([]*vex.VEX, error)
+	ParsePurl(string) (*purl.PackageURL, error)
+	GetPackageProbe(options.Options, *purl.PackageURL) (VexProbe, error)
+	FindDocumentsFromPurl(options.Options, VexProbe, *purl.PackageURL) ([]*vex.VEX, error)
 }
 
 type defaultAgentImplementation struct{}
 
 // ParsePurl checks if a purl is correctly formed
-func (pi *defaultAgentImplementation) ParsePurl(purlString string) (purl.PackageURL, error) {
+func (pi *defaultAgentImplementation) ParsePurl(purlString string) (*purl.PackageURL, error) {
 	p, err := purl.FromString(purlString)
 	if err != nil {
-		return p, err
+		return nil, err
 	}
-	return p, nil
+	return &p, nil
 }
 
 // GetPackageProbe returns a PackageProbe for the specified purl type
-func (pi *defaultAgentImplementation) GetPackageProbe(opts options.Options, p purl.PackageURL) (VexProbe, error) {
+func (pi *defaultAgentImplementation) GetPackageProbe(opts options.Options, p *purl.PackageURL) (VexProbe, error) {
 	if p, ok := probers[p.Type]; ok {
 		p.SetOptions(opts)
 		return p, nil
@@ -42,8 +42,8 @@ func (pi *defaultAgentImplementation) GetPackageProbe(opts options.Options, p pu
 
 // FetchDocuments downloads all OpenVEX documents using the PackageProbe for
 // the specified purl.
-func (pi *defaultAgentImplementation) FindDocumentsFromPurl(opts options.Options, pkgProbe VexProbe, p purl.PackageURL) ([]*vex.VEX, error) {
-	docs, err := pkgProbe.FindDocumentsFromPurl(opts, p)
+func (pi *defaultAgentImplementation) FindDocumentsFromPurl(opts options.Options, pkgProbe VexProbe, p *purl.PackageURL) ([]*vex.VEX, error) {
+	docs, err := pkgProbe.FindDocumentsFromPurl(opts, *p)
 	if err != nil {
 		return nil, fmt.Errorf("looking for documents: %w", err)
 	}

--- a/pkg/discovery/options/options.go
+++ b/pkg/discovery/options/options.go
@@ -11,7 +11,7 @@ import (
 
 type Options struct {
 	Logger  *slog.Logger
-	Context context.Context
+	Context context.Context //nolint:containedctx
 	// Prober options is a map keyed by purl types that holds free form structs
 	// that are passed as options to the corresponding PackageProber.
 	ProberOptions map[string]interface{}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -6,9 +6,8 @@ package oci
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/openvex/go-vex/pkg/vex"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateReferenceIdentifiers(t *testing.T) {

--- a/pkg/probers/oci/ocifakes/fake_oci_implementation.go
+++ b/pkg/probers/oci/ocifakes/fake_oci_implementation.go
@@ -26,11 +26,11 @@ type FakeOciImplementation struct {
 		result1 []*vex.VEX
 		result2 error
 	}
-	PurlToReferenceStub        func(options.Options, packageurl.PackageURL) (name.Reference, error)
+	PurlToReferenceStub        func(options.Options, *packageurl.PackageURL) (name.Reference, error)
 	purlToReferenceMutex       sync.RWMutex
 	purlToReferenceArgsForCall []struct {
 		arg1 options.Options
-		arg2 packageurl.PackageURL
+		arg2 *packageurl.PackageURL
 	}
 	purlToReferenceReturns struct {
 		result1 name.Reference
@@ -134,12 +134,12 @@ func (fake *FakeOciImplementation) DownloadDocumentsReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeOciImplementation) PurlToReference(arg1 options.Options, arg2 packageurl.PackageURL) (name.Reference, error) {
+func (fake *FakeOciImplementation) PurlToReference(arg1 options.Options, arg2 *packageurl.PackageURL) (name.Reference, error) {
 	fake.purlToReferenceMutex.Lock()
 	ret, specificReturn := fake.purlToReferenceReturnsOnCall[len(fake.purlToReferenceArgsForCall)]
 	fake.purlToReferenceArgsForCall = append(fake.purlToReferenceArgsForCall, struct {
 		arg1 options.Options
-		arg2 packageurl.PackageURL
+		arg2 *packageurl.PackageURL
 	}{arg1, arg2})
 	stub := fake.PurlToReferenceStub
 	fakeReturns := fake.purlToReferenceReturns
@@ -160,13 +160,13 @@ func (fake *FakeOciImplementation) PurlToReferenceCallCount() int {
 	return len(fake.purlToReferenceArgsForCall)
 }
 
-func (fake *FakeOciImplementation) PurlToReferenceCalls(stub func(options.Options, packageurl.PackageURL) (name.Reference, error)) {
+func (fake *FakeOciImplementation) PurlToReferenceCalls(stub func(options.Options, *packageurl.PackageURL) (name.Reference, error)) {
 	fake.purlToReferenceMutex.Lock()
 	defer fake.purlToReferenceMutex.Unlock()
 	fake.PurlToReferenceStub = stub
 }
 
-func (fake *FakeOciImplementation) PurlToReferenceArgsForCall(i int) (options.Options, packageurl.PackageURL) {
+func (fake *FakeOciImplementation) PurlToReferenceArgsForCall(i int) (options.Options, *packageurl.PackageURL) {
 	fake.purlToReferenceMutex.RLock()
 	defer fake.purlToReferenceMutex.RUnlock()
 	argsForCall := fake.purlToReferenceArgsForCall[i]

--- a/pkg/probers/oci/prober_test.go
+++ b/pkg/probers/oci/prober_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/openvex/discovery/pkg/discovery/options"
-	"github.com/openvex/discovery/pkg/probers/oci/ocifakes"
 	"github.com/openvex/go-vex/pkg/vex"
 	purl "github.com/package-url/packageurl-go"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openvex/discovery/pkg/discovery/options"
+	"github.com/openvex/discovery/pkg/probers/oci/ocifakes"
 )
 
 func TestDownloadDocuments(t *testing.T) {


### PR DESCRIPTION
This PR bumps the golangci lint version to v2.1. I've updated the workflows and fixed all the nits in the module code.

Signed-off-by: Adolfo Garcia Veytia (puerco) <adolfo.garcia@uservers.net>